### PR TITLE
Replace byte reference with pointer

### DIFF
--- a/include/sio4/crypto/drbg.hpp
+++ b/include/sio4/crypto/drbg.hpp
@@ -24,23 +24,30 @@ public:
    static constexpr unsigned int max_bytes_per_request = 65536;
    static constexpr unsigned int max_request_before_reseed = std::numeric_limits<unsigned int>::max();
 
-   hash_drbg(const bytes& entropy = bytes(), const bytes& nonce = bytes(), const bytes& personalization = bytes());
+   hash_drbg(const byte* entropy = nullptr, size_t entropy_length = 0, const byte* nonce = nullptr, size_t nonce_length = 0,
+      const byte* personalization = nullptr, size_t personalization_length = 0);
 
-   void generate_block(bytes& output, size_t size);
-   void generate_block(const bytes& additional, bytes& output, size_t size);
+   void incorporate_entropy(const byte* input, size_t length);
+   void incorporate_entropy(const byte* entropy, size_t entropy_length, const byte* additional, size_t additional_length);
+   void generate_block(byte* output, size_t size);
+   void generate_block(const byte* additional, size_t additional_length, byte* output, size_t size);
 
 protected:
-   void drbg_instantiate(const bytes& entropy, const bytes& nonce, const bytes& personalization);
-   void drbg_reseed(const bytes entropy, const bytes additional);
-   void hash_generate(const bytes& additional, bytes& output, size_t size);
-   void hash_update(const bytes& input1, const bytes& input2, const bytes& input3, const bytes& input4, bytes& output, size_t outlen);
+   void drbg_instantiate(const byte* entropy, size_t entropy_length, const byte* nonce, size_t nonce_length,
+      const byte* personalization, size_t personalization_length);
+   void drbg_reseed(const byte* entropy, size_t entropy_length, const byte* additional, size_t additional_length);
+   void hash_generate(const byte* additional, size_t additional_length, byte* output, size_t size);
+   void hash_update(const byte* input1, size_t inlen1, const byte* input2, size_t inlen2, const byte* input3, size_t inlen3,
+      const byte* input4, size_t inlen4, byte* output, size_t outlen);
 
 private:
    sha256 m_hash;
    bytes m_c, m_v, m_temp;
    uint64_t m_reseed;
 
-   inline void incremental_counter_by_one(bytes& inout, unsigned int size) {
+   inline void incremental_counter_by_one(byte* inout, unsigned int size) {
+      assert(inout != nullptr);
+
       unsigned int carry = 1;
       while (carry && size != 0) {
          carry = ! ++inout[size-1];
@@ -48,10 +55,10 @@ private:
       }
    }
 
-   inline bytes byte_reverse(uint32_t value) {
+   inline uint32_t byte_reverse(uint32_t value) {
       value = ((value & 0xFF00FF00) >> 8) | ((value & 0x00FF00FF) << 8);
       value = (value << 16) | (value >> 16);
-      return {(byte*)&value, (byte*)&value + sizeof(uint32_t)};
+      return value;
    }
 };
 

--- a/include/sio4/crypto/sha256.hpp
+++ b/include/sio4/crypto/sha256.hpp
@@ -14,9 +14,9 @@ public:
    sha256();
 
    void init();
-   void update(const bytes& input);
-   void final(bytes& digest);
-   void truncated_final(bytes& digest, size_t size);
+   void update(const byte* input, size_t length);
+   void final(byte* digest);
+   void truncated_final(byte* digest, size_t size);
 
 private:
    std::shared_ptr<sha256_impl> my;

--- a/src/drbg.cpp
+++ b/src/drbg.cpp
@@ -2,78 +2,83 @@
 
 namespace sio4 {
 
-hash_drbg::hash_drbg(const bytes& entropy, const bytes& nonce, const bytes& personalization)
+hash_drbg::hash_drbg(const byte* entropy, size_t entropy_length, const byte* nonce, size_t nonce_length, const byte* personalization, size_t personalization_length)
 : m_c(seed_length), m_v(seed_length), m_reseed(0) {
    std::memset(m_c.data(), 0x00, m_c.size());
    std::memset(m_v.data(), 0x00, m_v.size());
 
-   if (!entropy.empty()) {
-      drbg_instantiate(entropy, nonce, personalization);
+   if (entropy != nullptr && entropy_length != 0) {
+      drbg_instantiate(entropy, entropy_length, nonce, nonce_length, personalization, personalization_length);
    }
 }
 
-void hash_drbg::generate_block(bytes& output, size_t size) {
-   hash_generate(bytes(), output, size);
+void hash_drbg::incorporate_entropy(const byte* input, size_t length) {
+   return drbg_reseed(input, length, nullptr, 0);
 }
 
-void hash_drbg::generate_block(const bytes& additional, bytes& output, size_t size) {
-   hash_generate(additional, output, size);
+void hash_drbg::incorporate_entropy(const byte* entropy, size_t entropy_length, const byte* additional, size_t additional_length) {
+   return drbg_reseed(entropy, entropy_length, additional, additional_length);
 }
 
-void hash_drbg::drbg_instantiate(const bytes& entropy, const bytes& nonce, const bytes& personalization) {
-   check(entropy.size() >= min_entropy_length, "Insufficient entropy during instantiate");
-   assert(entropy.size() <= max_entropy_length);
-   assert(nonce.size() <= max_nonce_length);
-   assert(personalization.size() <= max_personalization_length);
+void hash_drbg::generate_block(byte* output, size_t size) {
+   hash_generate(nullptr, 0, output, size);
+}
 
-   const bytes zero = { 0 };
-   const bytes null = bytes();
+void hash_drbg::generate_block(const byte* additional, size_t additional_length, byte* output, size_t size) {
+   hash_generate(additional, additional_length, output, size);
+}
 
-   bytes t1, t2;
+void hash_drbg::drbg_instantiate(const byte* entropy, size_t entropy_length, const byte* nonce, size_t nonce_length, const byte* personalization, size_t personalization_length) {
+   check(entropy_length >= min_entropy_length, "Insufficient entropy during instantiate");
+   assert(entropy_length <= max_entropy_length);
+   assert(nonce_length <= max_nonce_length);
+   assert(personalization_length <= max_personalization_length);
 
-   hash_update(entropy, nonce, personalization, null, t1, seed_length);
-   hash_update(zero, t1, null, null, t2, seed_length);
+   const byte zero = 0;
+
+   bytes t1(seed_length), t2(seed_length);
+
+   hash_update(entropy, entropy_length, nonce, nonce_length, personalization, personalization_length, nullptr, 0, t1.data(), t1.size());
+   hash_update(&zero, 1, t1.data(), t1.size(), nullptr, 0, nullptr, 0, t2.data(), t2.size());
 
    m_v = t1;
    m_c = t2;
    m_reseed = 1;
 }
 
-void hash_drbg::drbg_reseed(const bytes entropy, const bytes additional) {
-   check(entropy.size() >= min_entropy_length, "Insufficient entropy during reseed");
-   assert(entropy.size() <= max_entropy_length);
-   assert(additional.size() <= max_additional_length);
+void hash_drbg::drbg_reseed(const byte* entropy, size_t entropy_length, const byte* additional, size_t additional_length) {
+   check(entropy_length >= min_entropy_length, "Insufficient entropy during reseed");
+   assert(entropy_length <= max_entropy_length);
+   assert(additional_length <= max_additional_length);
 
-   const bytes zero = { 0 };
-   const bytes one = { 1 };
-   const bytes null = bytes();
+   const byte zero = 0;
+   const byte one = 1;
 
-   bytes t1, t2;
-   t1.resize(seed_length);
-   t2.resize(seed_length);
+   bytes t1(seed_length), t2(seed_length);
 
-   hash_update(one, m_v, entropy, additional, t1, t1.size());
-   hash_update(zero, t1, null, null, t2, t2.size());
+   hash_update(&one, 1, m_v.data(), m_v.size(), entropy, entropy_length, additional, additional_length, t1.data(), t1.size());
+   hash_update(&zero, 1, t1.data(), t1.size(), nullptr, 0, nullptr, 0, t2.data(), t2.size());
 
    m_v = t1;
    m_c = t2;
    m_reseed = 1;
 }
 
-void hash_drbg::hash_generate(const bytes& additional, bytes& output, size_t size) {
+void hash_drbg::hash_generate(const byte* additional, size_t additional_length, byte* output, size_t size) {
    // Step 1
    check(static_cast<uint64_t>(m_reseed) < static_cast<uint64_t>(max_request_before_reseed), "Reseed required");
    check(size <= max_bytes_per_request, "Request size exceeds limit");
-   assert(additional.size() <= max_additional_length);
+   assert(additional_length <= max_additional_length);
 
    // Step 2
-   if (!additional.empty()) {
-      const bytes two = { 2 };
+   if (additional && additional_length) {
+      const byte two = 2;
+      m_temp.assign(sha256::digest_size, 0);
 
-      m_hash.update(two);
-      m_hash.update(m_v);
-      m_hash.update(additional);
-      m_hash.final(m_temp);
+      m_hash.update(&two, 1);
+      m_hash.update(m_v.data(), m_v.size());
+      m_hash.update(additional, additional_length);
+      m_hash.final(m_temp.data());
 
       assert(seed_length >= sha256::digest_size);
       int carry = 0;
@@ -96,28 +101,25 @@ void hash_drbg::hash_generate(const bytes& additional, bytes& output, size_t siz
    }
 
    // Step 3
-   output.resize(0);
    m_temp.assign(m_v.begin(), m_v.end());
    while (size) {
-      m_hash.update(m_temp);
+      m_hash.update(m_temp.data(), m_temp.size());
       size_t count = std::min(size, (size_t)sha256::digest_size);
+      m_hash.truncated_final(output, count);
 
-      bytes out;
-      m_hash.truncated_final(out, count);
-
-      incremental_counter_by_one(m_temp, static_cast<unsigned int>(m_temp.size()));
+      incremental_counter_by_one(m_temp.data(), static_cast<unsigned int>(m_temp.size()));
       size -= count;
-      output.insert(output.end(), out.begin(), out.end());
+      output+= count;
    }
 
    // Steps 4-7
    {
-      const bytes three = { 3 };
+      const byte three = 3;
       m_temp.assign(sha256::digest_size, 0);
 
-      m_hash.update(three);
-      m_hash.update(m_v);
-      m_hash.final(m_temp);
+      m_hash.update(&three, 1);
+      m_hash.update(m_v.data(), m_v.size());
+      m_hash.final(m_temp.data());
 
       assert(seed_length >= sha256::digest_size);
       assert(sha256::digest_size >= sizeof(m_reseed));
@@ -153,30 +155,29 @@ void hash_drbg::hash_generate(const bytes& additional, bytes& output, size_t siz
    m_reseed++;
 }
 
-void hash_drbg::hash_update(const bytes& input1, const bytes& input2, const bytes& input3, const bytes& input4, bytes& output, size_t outlen) {
-   bytes counter = { 1 };
-   bytes bits = byte_reverse(static_cast<uint32_t>(outlen * 8));
+void hash_drbg::hash_update(const byte* input1, size_t inlen1, const byte* input2, size_t inlen2, const byte* input3, size_t inlen3, const byte* input4, size_t inlen4, byte* output, size_t outlen) {
+   byte counter = 1;
+   uint32_t bits = byte_reverse(static_cast<uint32_t>(outlen * 8));
 
    while (outlen) {
-      m_hash.update(counter);
-      m_hash.update(bits);
+      m_hash.update(&counter, 1);
+      m_hash.update(reinterpret_cast<const byte*>(&bits), 4);
 
-      if (!input1.empty())
-         m_hash.update(input1);
-      if (!input2.empty())
-         m_hash.update(input2);
-      if (!input3.empty())
-         m_hash.update(input3);
-      if (!input4.empty())
-         m_hash.update(input4);
+      if (input1 && inlen1)
+         m_hash.update(input1, inlen1);
+      if (input2 && inlen2)
+         m_hash.update(input2, inlen2);
+      if (input3 && inlen3)
+         m_hash.update(input3, inlen3);
+      if (input4 && inlen4)
+         m_hash.update(input4, inlen4);
 
       size_t count = std::min(outlen, (size_t)sha256::digest_size);
+      m_hash.truncated_final(output, count);
 
-      bytes out;
-      m_hash.truncated_final(out, count);
-      output.insert(output.end(), out.begin(), out.end());
+      output += count;
       outlen -= count;
-      counter[0]++;
+      counter++;
    }
 }
 

--- a/src/sha256.cpp
+++ b/src/sha256.cpp
@@ -34,24 +34,22 @@ void sha256::init() {
    my->init();
 }
 
-void sha256::update(const bytes& input) {
-   my->update(reinterpret_cast<const uint8_t*>(input.data()), input.size());
+void sha256::update(const byte* input, size_t length) {
+   my->update(input, length);
 }
 
-void sha256::final(bytes& digest) {
-   my->final(reinterpret_cast<uint8_t*>(digest.data()));
+void sha256::final(byte* digest) {
+   my->final(digest);
    my->init();
 }
 
-void sha256::truncated_final(bytes& digest, size_t size) {
+void sha256::truncated_final(byte* digest, size_t size) {
    eosio::check(size <= digest_size, "Invalid digest size");
 
-   digest.resize(SHA256_DIGEST_LENGTH);
-   final(digest);
+   byte output[SHA256_DIGEST_LENGTH];
+   final(output);
 
-   if (size < digest_size) {
-      digest.resize(size);
-   }
+   std::memcpy(digest, output, size);
 }
 
 }


### PR DESCRIPTION
For convenience, the first version of sha256 and hash_drbg class passed the reference of byte, but it enforces developers to use std::vector and causes unintended mistakes. This PR changes the default type of parameters from the reference of byte to the pointer and its containing size.